### PR TITLE
Ordering of output vectors, `.loglik` and error on singularity issues

### DIFF
--- a/R/opsr.R
+++ b/R/opsr.R
@@ -156,6 +156,11 @@ opsr <- function(formula, data, subset, weights, na.action, start = NULL,
       rho <- grepl("^rho", names(start))
       start[rho] <- censor(start[rho], lower = -0.85, upper = 0.85)
     }
+    ## NA values point to singularity issues
+    if (any(is.na(start))) {
+      singular <- names(start)[is.na(start)]
+      stop("Singularity issues for ", deparse(singular))
+    }
   }
 
   fit <- opsr.fit(Ws, Xs, Ys, start, fixed, w,

--- a/R/opsr_fit.R
+++ b/R/opsr_fit.R
@@ -20,6 +20,8 @@
 #' @param nThreads number of threads to be used. Do not pass higher number than
 #'   number of ordinal outcomes. See also [`opsr_check_omp`] and [`opsr_max_threads`].
 #' @param .useR if `TRUE`, usese [`loglik_R`]. Go grab a coffe.
+#' @param .loglik if `TRUE`, returns the vector of log-likelihood values given
+#'   the parameters passed via `start`.
 #' @param ... further arguments passed to [`maxLik::maxLik`].
 #'
 #' @return object of class `"maxLik" "maxim"`.
@@ -27,12 +29,15 @@
 #' @seealso [`maxLik::maxLik`], [`loglik_cpp`], [`opsr`]
 #' @export
 opsr.fit <- function(Ws, Xs, Ys, start, fixed, weights,
-                     method, iterlim, printLevel, nThreads, .useR = FALSE, ...) {
+                     method, iterlim, printLevel, nThreads, .useR = FALSE,
+                     .loglik = FALSE, ...) {
   nReg <- length(Xs)
 
   ll <- ifelse(.useR, loglik_R, loglik_cpp)
 
   ll2 <- function(theta) ll(theta, Ws, Xs, Ys, weights, nReg, nThreads)
+
+  if (.loglik) return(ll2(start))
 
   mL <- maxLik::maxLik(ll2, start = start, fixed = fixed, method = method, iterlim = iterlim,
                        printLevel = printLevel, ...)

--- a/dev.R
+++ b/dev.R
@@ -684,3 +684,31 @@ debugonce(summary.opsr)
 
 fit_null <- opsr_null_model(fit_)
 summary(fit_null)
+
+
+## test .loglik
+devtools::load_all()
+sim_dat <- opsr_simulate()
+dat <- sim_dat$data
+dat[1, "yo"] <- -100
+dat[2, "yo"] <- -200
+f <- ys | yo ~ xs1 + xs2 | xo1 + xo2
+fit <- opsr(f, dat)
+logLik(fit)
+ll1 <- opsr(f, dat, .loglik = TRUE, start = fit$estimate)
+sum(ll1)
+ll1
+boxplot(ll1)
+which(ll1 < -50)
+ll2 <- fit$loglik(fit$estimate)
+sum(ll2)
+all(ll1 == ll2)
+
+?loglik_cpp
+mm <- model.matrix(fit)
+oZ <- order(dat$ys)
+Y <- lapply(sort(unique(dat$ys)), function(z) {
+  dat$yo[dat$ys == z]
+})
+ll3 <- loglik_cpp(fit$estimate, mm$W, mm$X, Y, fit$weights, 3, 1)[order(oZ)]
+all(ll1 == ll3)

--- a/man/opsr.Rd
+++ b/man/opsr.Rd
@@ -19,6 +19,7 @@ opsr(
   .get2step = FALSE,
   .useR = FALSE,
   .censorRho = TRUE,
+  .loglik = FALSE,
   ...
 )
 }
@@ -71,6 +72,9 @@ not proceed with the maximum likelihood estimation.}
 
 \item{.censorRho}{if \code{TRUE}, rho starting values are censored to lie in the
 interval [-0.85, 0.85].}
+
+\item{.loglik}{if \code{TRUE}, returns the vector of log-likelihood values given
+the parameters passed via \code{start}.}
 
 \item{...}{further arguments passed to \code{\link[maxLik:maxLik]{maxLik::maxLik}}.}
 }

--- a/man/opsr.fit.Rd
+++ b/man/opsr.fit.Rd
@@ -16,6 +16,7 @@ opsr.fit(
   printLevel,
   nThreads,
   .useR = FALSE,
+  .loglik = FALSE,
   ...
 )
 }
@@ -45,6 +46,9 @@ outcome).}
 number of ordinal outcomes. See also \code{\link{opsr_check_omp}} and \code{\link{opsr_max_threads}}.}
 
 \item{.useR}{if \code{TRUE}, usese \code{\link{loglik_R}}. Go grab a coffe.}
+
+\item{.loglik}{if \code{TRUE}, returns the vector of log-likelihood values given
+the parameters passed via \code{start}.}
 
 \item{...}{further arguments passed to \code{\link[maxLik:maxLik]{maxLik::maxLik}}.}
 }


### PR DESCRIPTION
Resolves the following issues:

- https://github.com/dheimgartner/OPSR/issues/11
- https://github.com/dheimgartner/OPSR/issues/12