### PR TITLE
JSS comments revision 2

### DIFF
--- a/R/opsr_simulate.R
+++ b/R/opsr_simulate.R
@@ -46,6 +46,8 @@ errors <- function(Sigma, nobs = 1000) {
 #'
 #' @param nobs number of observations to simulate.
 #' @param sigma the covariance matrix of the multivariate normal.
+#' @param seed a single value, interpreted as an integer, or `NULL` passed to
+#'   [`set.seed`].
 #'
 #' @return Named list:
 #' \item{params}{ground truth parameters.}
@@ -61,7 +63,11 @@ errors <- function(Sigma, nobs = 1000) {
 #' process.
 #'
 #' @export
-opsr_simulate <- function(nobs = 1000, sigma = NULL) {
+opsr_simulate <- function(nobs = 1000, sigma = NULL, seed = NULL) {
+  if (!is.null(seed)) {
+    set.seed(seed)
+  }
+
   ## same regressors in selection and outcome might lead to identification issues
   X <- obs_mat(nobs, p = 2, sd = 1)
   colnames(X) <- paste0("xo", 1:ncol(X))

--- a/R/opsr_te.R
+++ b/R/opsr_te.R
@@ -14,7 +14,9 @@
 #' @seealso [`summary.opsr.te`]
 #' @example R/examples/ex-opsr_te.R
 #' @export
-opsr_te <- function(object, type, weights = NULL, ...) {
+opsr_te <- function(object, type = c("response", "unlog-response", "prob", "mills", "correction", "Xb"),
+                    weights = NULL, ...) {
+  type <- match.arg(type)
   if (is.null(weights)) {
     weights <- object$weights
   }

--- a/R/plot_opsr.R
+++ b/R/plot_opsr.R
@@ -11,7 +11,9 @@
 #'
 #' @method plot opsr
 #' @export
-plot.opsr <- function(x, type, weights = NULL, ...) {
+plot.opsr <- function(x, type = c("response", "unlog-response", "prob", "mills", "correction", "Xb"),
+                      weights = NULL, ...) {
+  type <- match.arg(type)
   te <- opsr_te(x, type = type, weights = weights)
   graphics::pairs(te, ...)
   invisible(x)

--- a/man/opsr_simulate.Rd
+++ b/man/opsr_simulate.Rd
@@ -4,12 +4,15 @@
 \alias{opsr_simulate}
 \title{Simulate Data from an OPSR Process}
 \usage{
-opsr_simulate(nobs = 1000, sigma = NULL)
+opsr_simulate(nobs = 1000, sigma = NULL, seed = NULL)
 }
 \arguments{
 \item{nobs}{number of observations to simulate.}
 
 \item{sigma}{the covariance matrix of the multivariate normal.}
+
+\item{seed}{a single value, interpreted as an integer, or \code{NULL} passed to
+\code{\link{set.seed}}.}
 }
 \value{
 Named list:

--- a/man/opsr_te.Rd
+++ b/man/opsr_te.Rd
@@ -4,7 +4,12 @@
 \alias{opsr_te}
 \title{Treatment Effect Computations for OPSR Model Fits}
 \usage{
-opsr_te(object, type, weights = NULL, ...)
+opsr_te(
+  object,
+  type = c("response", "unlog-response", "prob", "mills", "correction", "Xb"),
+  weights = NULL,
+  ...
+)
 }
 \arguments{
 \item{object}{object an object of class \code{"opsr"}.}

--- a/man/plot.opsr.Rd
+++ b/man/plot.opsr.Rd
@@ -4,7 +4,12 @@
 \alias{plot.opsr}
 \title{Plot Method for OPSR Model Fits}
 \usage{
-\method{plot}{opsr}(x, type, weights = NULL, ...)
+\method{plot}{opsr}(
+  x,
+  type = c("response", "unlog-response", "prob", "mills", "correction", "Xb"),
+  weights = NULL,
+  ...
+)
 }
 \arguments{
 \item{x}{an object of class \code{"opsr"}.}

--- a/vignettes/opsr.Rnw
+++ b/vignettes/opsr.Rnw
@@ -318,7 +318,7 @@ We first illustrate how to specify a model using \pkg{Formula}'s extended syntax
 Let us simulate date from an OPSR process with three ordinal outcomes and distinct design matrices $\boldsymbol{W}$ and $\boldsymbol{X}$ (where $\boldsymbol{X} = \boldsymbol{X_j} \ \forall{j}$) by
 %
 <<sim-dat>>=
-sim_dat <- opsr_simulate()
+sim_dat <- opsr_simulate(seed = 0)
 dat <- sim_dat$data
 head(dat)
 @


### PR DESCRIPTION
- See https://github.com/dheimgartner/OPSR/issues/37
- `seed` arg in `opsr_simulate()` to ensure reproducibility
- `type` arg list (with default) to make `plot.opsr()` and `opsr_te()` behave similarly to `predict.opsr()`